### PR TITLE
Update index.js FIlename draft_info.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function msToSrt(timeInMs) {
   }:${seconds < 10 ? "0" + seconds : seconds},${ms}`;
 }
 
-var draftFileName = "draft_content.json";
+var draftFileName = "draft_info.json";
 let os = process.env.os;
 switch (os) {
   case "Windows_NT":


### PR DESCRIPTION
CapCut now uses draft_info.json as the default filename. Let's use this for the web app runner. The local script should continue to work for Windows NT.